### PR TITLE
Small optimization

### DIFF
--- a/src/main/java/com/metin/singleton/design/pattern/thread/safe/SingletonPatternThreadSafeExample.java
+++ b/src/main/java/com/metin/singleton/design/pattern/thread/safe/SingletonPatternThreadSafeExample.java
@@ -10,18 +10,16 @@ public class SingletonPatternThreadSafeExample implements Serializable {
     }
 
     public static SingletonPatternThreadSafeExample getInstance() {
-
-        if (instance == null) {
+        SingletonPatternThreadSafeExample result = instance;
+        if (result == null) {
 
             synchronized (SingletonPatternThreadSafeExample.class) {
-
-                if (instance == null) {
-                    instance = new SingletonPatternThreadSafeExample();
+                if (result == null) {
+                    instance = result = new SingletonPatternThreadSafeExample();
                 }
             }
         }
-
-        return instance;
+        return result;
     }
 
     public Object readResolve(){


### PR DESCRIPTION
The local variable result seems unnecessary. But, it’s there to improve the performance of our code. In cases where the instance is already initialized (most of the time), the volatile field is only accessed once (due to “return result;” instead of “return instance;”). This can improve the method’s overall performance by as much as 25 percent.

Reference : https://www.journaldev.com/171/thread-safety-in-java-singleton-classes